### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -6,6 +6,8 @@ jobs:
   main-job:
     name: Main Job
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
   workflow-keepalive:


### PR DESCRIPTION
Potential fix for [https://github.com/leben-in-deutschland/leben-in-deutschland-app/security/code-scanning/9](https://github.com/leben-in-deutschland/leben-in-deutschland-app/security/code-scanning/9)

To fix the issue, we will add a `permissions` block to the `main-job` job, explicitly setting the permissions to `contents: read`. This ensures that the job has only the minimal permissions required to perform its tasks. The `workflow-keepalive` job already has a `permissions` block, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
